### PR TITLE
docs: add rule sources with steerspec.dev URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # strspc-CLI
+
+SteerSpec CLI — user-facing command-line tool for the SteerSpec ecosystem.
+
+## Rule sources
+
+The CLI consumes rules and schemas published at
+[steerspec.dev](https://steerspec.dev) from
+[strspc-rules](https://github.com/SteerSpec/strspc-rules):
+
+| Resource | URL |
+| -------- | --- |
+| Entity schema | `https://steerspec.dev/schemas/entity/v1.json` |
+| Bootstrap schema | `https://steerspec.dev/schemas/entity/bootstrap.json` |
+| Rules manifest | `https://steerspec.dev/rules/latest/index.json` |
+| Versioned rules | `https://steerspec.dev/rules/v<version>/` |


### PR DESCRIPTION
## Summary

- Add Rule Sources section to README documenting the steerspec.dev schema and rules URLs the CLI will consume

Part of cross-repo docs update for the new strspc-rules publishing pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)