### PR TITLE
fix(ci): use PAT in release-please to trigger GoReleaser

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,5 +14,8 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
+          # Use a PAT so the created tag triggers the GoReleaser workflow.
+          # Default GITHUB_TOKEN pushes do not trigger other workflows.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary

- Use `RELEASE_PLEASE_TOKEN` (org secret) instead of default `GITHUB_TOKEN` so tags created by release-please trigger the GoReleaser workflow
- Matches fix applied in strspc-manager via [strspc-manager#14](https://github.com/SteerSpec/strspc-manager/pull/14)

Closes #21

## Test plan

- [ ] Merge to main triggers release-please
- [ ] Release-please tag creation triggers GoReleaser `release.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)