### PR TITLE
ci: auto-approve PRs once Copilot's review is clean

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,7 +1,17 @@
 name: PR Auto-Approve (Copilot)
 
-# Copy this file to .github/workflows/pr-auto-approve.yml in your repository.
-# Then set the required variables/secrets (see comments below).
+# This IS the live workflow for this repo -- not a template to copy anywhere.
+#
+# It was generated from templates/pr-auto-approve.yml in SteerSpec/strspc-pr-review
+# (v1.4.0) with only the per-repo values changed: bot-login as a literal,
+# secrets.BOT_TOKEN, the base branch, the workflow_run list, and the Copilot
+# wait. The comments below are inherited from that template and kept
+# deliberately: each documents something that silently broke in production, and
+# a wrong value here produces no error at all, just a PR that is never approved.
+#
+# When the action changes, the pr-caller-sync skill finds callers like this one
+# and proposes the matching edit -- which works only while the diff against the
+# template stays small. Prefer changing the template upstream over diverging here.
 
 on:
   # SECURITY: pull_request_target, NOT pull_request. For a same-repo PR the

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,151 @@
+name: PR Auto-Approve (Copilot)
+
+# Copy this file to .github/workflows/pr-auto-approve.yml in your repository.
+# Then set the required variables/secrets (see comments below).
+
+on:
+  # SECURITY: pull_request_target, NOT pull_request. For a same-repo PR the
+  # `pull_request` event runs the workflow definition from the PR's HEAD commit
+  # with your secrets in scope, so anyone who can push a branch could edit this
+  # file in their own PR and exfiltrate the bot token. `pull_request_target`
+  # instead "runs in the context of the default branch of the base repository",
+  # so the definition is never PR-controlled. Note "default branch", not "base
+  # branch": they differ whenever a PR targets a non-default branch.
+  #
+  # The usual pull_request_target footgun does not apply here: it is dangerous
+  # when you check out and execute PR code with secrets in scope, and this
+  # workflow never checks anything out — the action only calls the GitHub API.
+  # If you add a checkout step, stop and reconsider.
+  #
+  # It also makes the fork guard in the if: below load-bearing rather than
+  # belt-and-braces. Do not remove it.
+  pull_request_target:
+    branches: [main]
+    types: [opened, ready_for_review, synchronize, reopened]
+  # Safe as-is: pull_request_review "will only trigger a workflow run if the
+  # workflow file exists on the default branch", so the definition is not
+  # PR-controlled and this is not an injection path. Its GITHUB_REF is still the
+  # PR merge ref, so a checkout step here WOULD pull PR code — do not add one.
+  pull_request_review:
+    types: [submitted]
+  # check_run catches checks posted by third-party apps (external CI services).
+  # It does NOT fire for checks produced by your own GitHub Actions workflows:
+  # Actions creates those with GITHUB_TOKEN, and GITHUB_TOKEN-generated events
+  # never start a new workflow run (GitHub's recursion guard).
+  check_run:
+    types: [completed]
+  # REQUIRED IF YOUR CI IS GITHUB ACTIONS — see the note above. Without this,
+  # a PR whose Copilot review arrives BEFORE CI finishes is never re-evaluated:
+  # the review-triggered run skips with "check still running" and nothing ever
+  # follows, so the PR silently never gets approved.
+  #
+  # List the workflow(s) that must pass, by their `name:` value. Then also OR
+  # the workflow_run branch into the job if: below (already included) and keep
+  # `github.event.workflow_run.pull_requests[0].number ||` in the concurrency
+  # group. Delete this trigger only if all your gating checks come from
+  # third-party apps rather than Actions.
+  workflow_run:
+    workflows: ['CI']
+    types: [completed]
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+      checks: read
+    # Serialize runs per PR to avoid race conditions.
+    # For check_run events the PR number comes from check_run.pull_requests[0].number.
+    concurrency:
+      group: >-
+        pr-auto-approve-${{ github.repository }}-${{
+          github.event.pull_request.number ||
+          github.event.check_run.pull_requests[0].number ||
+          github.event.workflow_run.pull_requests[0].number ||
+          github.run_id
+        }}
+      cancel-in-progress: true
+    # Skip fork PRs and draft PRs. The fork guard is REQUIRED, not optional:
+    # with pull_request_target the run would otherwise get your secrets while
+    # associated with a fork. Handle both pull_request_target and
+    # pull_request_review (a Copilot review submission should
+    # re-evaluate the PR), but guard the review path with actor != bot-login so
+    # the bot's own APPROVE review never re-triggers this workflow (loop-guard).
+    # The guard hard-codes 'cnslr-bt' rather than reading a repo variable: an
+    # unset vars.PR_AUTO_APPROVE_BOT_LOGIN makes this comparison `actor != ''`,
+    # which is always true, silently disabling the loop guard. A literal cannot
+    # fail open. It MUST stay identical to the bot-login input below.
+    # Allow check_run events through but exclude this job's own check to prevent
+    # feedback loops — update 'auto-approve' below if you rename this job.
+    # BASE-BRANCH SYNC — 3 points must list the same branch(es):
+    #   1. on.pull_request_target.branches (above)   2. the base.ref check (below)
+    #   3. the base-branch input (at the bottom).
+    # For multiple base branches, set branches: [main, develop] above and change
+    # the base.ref line below to:
+    #   contains(fromJSON('["main","develop"]'), github.event.pull_request.base.ref)
+    # The workflow_run branch below pairs with the trigger in the `on:` section.
+    # The pull_requests[0] != null guard matters: workflow_run fires for EVERY
+    # completed run of the named workflow, including non-PR runs (e.g. a push to
+    # main), which have an empty pull_requests array -- without the guard those
+    # trigger a wasted job run and a noisy "skipped: workflow_run: no associated
+    # PRs" Slack notification. Delete that branch only if you also deleted the
+    # workflow_run trigger.
+    if: >-
+      (
+        (
+          github.event_name == 'pull_request_target' ||
+          (
+            github.event_name == 'pull_request_review' &&
+            github.actor != 'cnslr-bt'
+          )
+        ) &&
+        github.event.pull_request.base.ref == 'main' &&
+        github.event.pull_request.draft == false &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      ) || (
+        github.event_name == 'check_run' &&
+        github.event.check_run.name != 'auto-approve' &&
+        github.event.check_run.pull_requests[0] != null
+      ) || (
+        github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_repository.full_name == github.repository &&
+        github.event.workflow_run.pull_requests[0] != null
+      )
+    steps:
+      # @v1 tracks the latest v1.x release. Pin an exact @vX.Y.Z if you prefer
+      # to upgrade manually.
+      - uses: SteerSpec/strspc-pr-review@v1
+        with:
+          # Required: GitHub login of the bot account that will approve PRs.
+          # A literal, not vars.PR_AUTO_APPROVE_BOT_LOGIN: an unset variable makes
+          # the loop guard in the if: read `actor != ''`, which is always true, so
+          # it would fail OPEN. Must stay identical to the guard above.
+          bot-login: cnslr-bt
+
+          # Required: PAT for bot-login with `repo` scope so it can post reviews.
+          bot-github-token: ${{ secrets.BOT_TOKEN }}
+
+          # Optional: base branch(es) PRs must target (default: main). Accepts a
+          # comma-separated set, e.g. 'develop,main'. Keep in sync with the
+          # branches: filter and base.ref check above (see BASE-BRANCH SYNC).
+          # base-branch: develop
+
+          # STRONGLY RECOMMENDED if Copilot reviews your PRs. Without it, a PR
+          # whose Copilot review lands AFTER CI is never re-evaluated and sits
+          # unapproved forever: Copilot's check_run is GITHUB_TOKEN-created, and
+          # any workflow run Copilot itself triggers is held at 'action_required'
+          # pending manual approval. This makes the CI-triggered run wait for
+          # Copilot's check instead of skipping. Free on public repos; consumes
+          # billable Actions minutes on private ones, hence off by default.
+          wait-for-copilot-seconds: '300'
+
+          # Optional: set to 'true' if your repo has no CI checks for some PRs
+          # (e.g. docs-only repos or PRs that skip CI via path filters).
+          # When 'false' (default), PRs with no external checks are never approved.
+          # allow-no-checks: 'false'
+
+          # Optional: Slack bot token for approval/skip/error notifications.
+          # Remove this line to disable Slack notifications.
+          # slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
The org ruleset requires one approving review on this repo's default branch, and nothing here could ever supply it — every PR was stuck waiting for a human with no automated path to approval.

This is the same caller workflow already running in [`strspc-pr-review`](https://github.com/SteerSpec/strspc-pr-review) and [`strspc-sync`](https://github.com/SteerSpec/strspc-sync), copied from `templates/pr-auto-approve.yml` at `v1.4.0`. Only the values that must differ per repo were changed; the inline comments are kept verbatim because each one documents something that silently broke in production.

## What was changed from the template

| Value | Set to | Why |
|---|---|---|
| `bot-login` (and the loop guard) | literal `cnslr-bt` | an unset `vars.PR_AUTO_APPROVE_BOT_LOGIN` makes the guard read `actor != ''` — always true — so it fails **open**. A literal cannot |
| `bot-github-token` | `secrets.BOT_TOKEN` | this org's secret name |
| `wait-for-copilot-seconds` | `'300'` | public repo, so the wait is free. Without it, a PR whose Copilot review arrives *after* CI is never re-evaluated and sits unapproved forever |

`CI` is already `pull_request`-triggered here, so the `workflow_run` re-entry trigger needed no change — and the approval stays evidence-based rather than resting on Copilot alone.

## This PR needs one manual approval

`pull_request_target` reads the workflow definition from the **default branch**, which doesn't have it yet. That's the bootstrap; it happens exactly once per repo. Every PR after this one should approve itself.
